### PR TITLE
[ROCm] Add an AMD GPU build with HIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ x86/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+
+# CMake build directory (ROCm port)
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,9 @@ option(USE_HIP "Build with HIP for AMD GPUs" OFF)
 
 # GPU language setup
 if(USE_HIP)
+  # enable_language(HIP) auto-detects the host GPU arch (and errors on a
+  # no-GPU host); pass -DCMAKE_HIP_ARCHITECTURES to override.
   enable_language(HIP)
-  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
-    set(CMAKE_HIP_ARCHITECTURES "gfx90a")
-  endif()
   message(STATUS "Building with HIP, architectures: ${CMAKE_HIP_ARCHITECTURES}")
 else()
   enable_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(Velvet LANGUAGES C CXX)
+
+option(USE_HIP "Build with HIP for AMD GPUs" OFF)
+
+# GPU language setup
+if(USE_HIP)
+  enable_language(HIP)
+  if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+    set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+  endif()
+  message(STATUS "Building with HIP, architectures: ${CMAKE_HIP_ARCHITECTURES}")
+else()
+  enable_language(CUDA)
+  message(STATUS "Building with CUDA")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find required packages (all provided via vcpkg)
+find_package(OpenGL REQUIRED)
+find_package(glfw3 CONFIG REQUIRED)
+find_package(glad CONFIG REQUIRED)
+find_package(glm CONFIG REQUIRED)
+find_package(fmt CONFIG REQUIRED)
+find_package(assimp CONFIG REQUIRED)
+find_package(imgui CONFIG REQUIRED)
+
+# HIP-specific dependencies
+if(USE_HIP)
+  find_package(hipcub REQUIRED)
+  find_package(rocthrust REQUIRED)
+endif()
+
+# Host/GPU sources. Upstream keeps these as .cpp (built by MSVC) plus the two
+# .cu files (built by nvcc) in Velvet.vcxproj; that layout is preserved here.
+# The .cpp files include device code through Common.cuh, so the HIP build below
+# compiles them as HIP via LANGUAGE without renaming, leaving the Visual Studio
+# CUDA build (which references the .cpp names) intact.
+set(CPP_SOURCES
+  Velvet/Actor.cpp
+  Velvet/Component.cpp
+  Velvet/GUI.cpp
+  Velvet/GameInstance.cpp
+  Velvet/Helper.cpp
+  Velvet/Input.cpp
+  Velvet/MeshRenderer.cpp
+  Velvet/Timer.cpp
+  Velvet/VtEngine.cpp
+  Velvet/stb_image.cpp
+  Velvet/main.cpp
+)
+set(CU_SOURCES
+  Velvet/VtClothSolverGPU.cu
+  Velvet/SpatialHashGPU.cu
+)
+set(SOURCES ${CPP_SOURCES} ${CU_SOURCES})
+
+# Create executable
+add_executable(Velvet ${SOURCES})
+
+if(USE_HIP)
+  # Compile every source as HIP. A mixed CXX/HIP target would apply the HIP
+  # arch flags to the .cpp sources as plain C++ and fail, so mark them all HIP.
+  set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE HIP)
+  target_compile_definitions(Velvet PRIVATE USE_HIP)
+  target_link_libraries(Velvet PRIVATE hip::hipcub roc::rocthrust)
+  set_target_properties(Velvet PROPERTIES
+    HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}"
+  )
+endif()
+# For the non-HIP (CUDA) build, language auto-detection drives the split:
+# .cpp -> CXX, .cu -> CUDA, matching upstream's Visual Studio project.
+
+# Include directories
+target_include_directories(Velvet PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/Velvet
+  ${CMAKE_CURRENT_SOURCE_DIR}/Velvet/External
+  ${CMAKE_CURRENT_SOURCE_DIR}/Velvet/External/cuda
+)
+
+# Link libraries
+target_link_libraries(Velvet PRIVATE
+  OpenGL::GL
+  glfw
+  glad::glad
+  glm::glm
+  fmt::fmt
+  assimp::assimp
+  imgui::imgui
+)
+
+# Set output directory
+set_target_properties(Velvet PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+# Copy assets to build directory
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Velvet/Assets")
+  add_custom_command(TARGET Velvet POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    "${CMAKE_CURRENT_SOURCE_DIR}/Velvet/Assets"
+    "$<TARGET_FILE_DIR:Velvet>/Assets"
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,9 @@ if(USE_HIP)
 endif()
 
 # Host/GPU sources. Upstream keeps these as .cpp (built by MSVC) plus the two
-# .cu files (built by nvcc) in Velvet.vcxproj; that layout is preserved here.
-# The .cpp files include device code through Common.cuh, so the HIP build below
-# compiles them as HIP via LANGUAGE without renaming, leaving the Visual Studio
-# CUDA build (which references the .cpp names) intact.
+# .cu files (built by nvcc) in Velvet.vcxproj; that layout is preserved here,
+# and the AMD build below keeps the same split: the .cu files carry every
+# kernel and every launch, the .cpp files are host code.
 set(CPP_SOURCES
   Velvet/Actor.cpp
   Velvet/Component.cpp
@@ -61,11 +60,31 @@ set(SOURCES ${CPP_SOURCES} ${CU_SOURCES})
 add_executable(Velvet ${SOURCES})
 
 if(USE_HIP)
-  # Compile every source as HIP. A mixed CXX/HIP target would apply the HIP
-  # arch flags to the .cpp sources as plain C++ and fail, so mark them all HIP.
-  set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE HIP)
+  # Only the device-code sources are HIP translation units. The host .cpp files
+  # must stay C++: the GPU compiler defines __HIPCC__, and Common.hpp keys
+  # HOST_INIT() off that macro to drop the default member initializers of
+  # VtSimParams (a __device__ __constant__ copy of it cannot be dynamically
+  # initialized). Compiling the host files as GPU sources therefore zeroed the
+  # host copy of the simulation parameters too, so the solver ran with zero
+  # substeps and zero gravity. This mirrors the NVIDIA build, where the .cpp
+  # files are plain C++ and never see __CUDACC__.
+  set_source_files_properties(${CU_SOURCES} PROPERTIES LANGUAGE HIP)
   target_compile_definitions(Velvet PRIVATE USE_HIP)
-  target_link_libraries(Velvet PRIVATE hip::hipcub roc::rocthrust)
+  # hipCUB and rocThrust are header only, but their imported targets pull in
+  # hip::device, whose interface appends "-x hip --offload-arch=..." to every
+  # C++ source of the consuming target. That is what makes a mixed-language
+  # target fail; take their header search paths instead, and link only
+  # hip::host, for the runtime library and __HIP_PLATFORM_AMD__.
+  foreach(rocm_target hip::hipcub roc::rocthrust roc::rocprim_hip)
+    if(TARGET ${rocm_target})
+      get_target_property(rocm_target_includes ${rocm_target}
+        INTERFACE_INCLUDE_DIRECTORIES)
+      if(rocm_target_includes)
+        target_include_directories(Velvet SYSTEM PRIVATE ${rocm_target_includes})
+      endif()
+    endif()
+  endforeach()
+  target_link_libraries(Velvet PRIVATE hip::host)
   set_target_properties(Velvet PROPERTIES
     HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,16 @@ endif()
 target_include_directories(Velvet PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/Velvet
   ${CMAKE_CURRENT_SOURCE_DIR}/Velvet/External
-  ${CMAKE_CURRENT_SOURCE_DIR}/Velvet/External/cuda
 )
+
+if(NOT USE_HIP)
+  # The bundled CUDA samples helpers are for the CUDA build only. The HIP build
+  # defines checkCudaErrors itself in Velvet/cuda_to_hip.h and never puts this
+  # directory on the include path.
+  target_include_directories(Velvet PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/Velvet/External/cuda
+  )
+endif()
 
 # Link libraries
 target_link_libraries(Velvet PRIVATE

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ If you want to build from source by yourself, dependencies can be installed usin
 ./vcpkg.exe install imgui[core, opengl3-binding, glfw-binding]:x64-windows
 ```
 
+### Building for AMD GPUs (ROCm/HIP)
+
+Velvet also builds for AMD GPUs with ROCm/HIP through CMake. The same dependencies are available from vcpkg using the `x64-linux` triplet:
+
+```bash
+./vcpkg install glfw3 glad fmt glm assimp "imgui[core,opengl3-binding,glfw-binding]" --triplet x64-linux
+```
+
+Then configure with `USE_HIP=ON`, selecting your GPU architecture with `CMAKE_HIP_ARCHITECTURES` (for example `gfx1100` or `gfx1201`):
+
+```bash
+cmake -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx1100 \
+      -DCMAKE_TOOLCHAIN_FILE=<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake
+cmake --build build -j
+```
+
+Velvet renders with OpenGL and shares buffers with the GPU, so it needs an AMD GPU with a graphics pipeline (RDNA, such as the Radeon RX 7000/9000 series). Compute-only datacenter GPUs (CDNA, such as the Instinct MI series) cannot create the OpenGL context Velvet requires.
+
 ## Implementation Details
 
 In computer graphics, building your own wheel can often be unevitable. But what fears most is that sometimes you don't even have recipe for the wheel you want to build. There are lots of great paper describing their methods, but many of the implementation details are left out or scattered across the internet.

--- a/README.md
+++ b/README.md
@@ -61,10 +61,14 @@ Velvet also builds for AMD GPUs with ROCm/HIP through CMake. The same dependenci
 ./vcpkg install glfw3 glad fmt glm assimp "imgui[core,opengl3-binding,glfw-binding]" --triplet x64-linux
 ```
 
-Then configure with `USE_HIP=ON`, selecting your GPU architecture with `CMAKE_HIP_ARCHITECTURES` (for example `gfx1100` or `gfx1201`):
+Then configure with `USE_HIP=ON`, selecting your GPU architecture with `CMAKE_HIP_ARCHITECTURES` (for example `gfx1100` or `gfx1201`). Only the two `.cu` files are compiled as HIP, but the plain C++ sources reach the hipCUB, rocThrust and HIP runtime headers through `Velvet/Common.cuh`, so the ROCm clang is required for `CMAKE_CXX_COMPILER` as well as for `CMAKE_HIP_COMPILER`. This is the invocation the ROCm build is verified with, where `ROCM_PATH` is your ROCm installation prefix (`/opt/rocm` by default):
 
 ```bash
 cmake -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx1100 \
+      -DCMAKE_C_COMPILER=$ROCM_PATH/lib/llvm/bin/clang \
+      -DCMAKE_CXX_COMPILER=$ROCM_PATH/lib/llvm/bin/clang++ \
+      -DCMAKE_HIP_COMPILER=$ROCM_PATH/lib/llvm/bin/clang++ \
+      -DCMAKE_PREFIX_PATH=$ROCM_PATH \
       -DCMAKE_TOOLCHAIN_FILE=<path-to-vcpkg>/scripts/buildsystems/vcpkg.cmake
 cmake --build build -j
 ```

--- a/Velvet/Common.cuh
+++ b/Velvet/Common.cuh
@@ -1,16 +1,27 @@
 #pragma once
 
 #include <tuple>
+#include <cstring>
+#include <cstdlib>
+
+// cuda_to_hip.h MUST come before glm so GLM_FORCE_CUDA et al. are defined
+#include "cuda_to_hip.h"
 
 #include <fmt/format.h>
 #include <glm/glm.hpp>
 
-#include <cuda_runtime.h> 
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+// HIP path: hip_runtime.h is included via cuda_to_hip.h
+#else
+// CUDA path
+#include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
 #include <device_launch_parameters.h>
 #include <helper_cuda.h>
 #include <helper_math.h>
+#endif
 
+// cuda_to_hip.h already defines THRUST_DEVICE_COMPILER=5 for HIP backend
 #include <thrust/device_ptr.h>
 #include <thrust/transform.h>
 #include <thrust/sort.h>
@@ -20,7 +31,7 @@
 #define GET_CUDA_ID_NO_RETURN(id, maxID) 	uint id = blockIdx.x * blockDim.x + threadIdx.x
 #define EPSILON					1e-6f
 
-#ifdef __CUDACC__ 
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #define CUDA_CALL(func, totalThreads)  \
 	if (totalThreads == 0) return; \
 	uint func ## _numBlocks, func ## _numThreads; \

--- a/Velvet/Common.hpp
+++ b/Velvet/Common.hpp
@@ -7,11 +7,12 @@
 
 #define IMGUI_LEFT_LABEL(func, label, ...) (ImGui::TextUnformatted(label), ImGui::SameLine(), func("##" label, __VA_ARGS__))
 
-// Only initialize value on host. 
-// Since CUDA doesn't allow dynamics initialization, 
-// we use this macro to ignore initialization when compiling with NVCC.
-#ifdef __CUDA_ARCH__
-	#define HOST_INIT(val) 
+// Only initialize value on host.
+// Since CUDA/HIP does not allow dynamic initialization for __device__ variables,
+// suppress default member initializers when compiling with NVCC or hipcc.
+// The struct is used both as a host variable and as __device__ __constant__.
+#if defined(__CUDACC__) || defined(__HIPCC__)
+	#define HOST_INIT(val)
 #else
 	#define HOST_INIT(val) = val
 #endif
@@ -87,12 +88,15 @@ public:
 		m_funcs.push_back(func);
 	}
 
-	template <class... TArgs>
-	void Invoke(TArgs... args)
+	// Named Args, not TArgs: VtCallback already has a TArgs parameter pack, and
+	// reusing that name here shadows it, which nvcc/gcc reject ("shadows
+	// template parameter"). Keep this name distinct.
+	template <class... Args>
+	void Invoke(Args... args)
 	{
 		for (const auto& func : m_funcs)
 		{
-			func(std::forward<TArgs>(args)...);
+			func(std::forward<Args>(args)...);
 		}
 	}
 

--- a/Velvet/Component.hpp
+++ b/Velvet/Component.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <string>
 
 #include "Transform.hpp"

--- a/Velvet/External/cuda/helper_cuda.h
+++ b/Velvet/External/cuda/helper_cuda.h
@@ -1,12 +1,28 @@
-/**
- * Copyright 1993-2017 NVIDIA Corporation.  All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
- * Please refer to the NVIDIA end user license agreement (EULA) associated
- * with this source code for terms and conditions that govern your use of
- * this software. Any use, reproduction, disclosure, or distribution of
- * this software and related documentation outside the terms of the EULA
- * is strictly prohibited.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -122,14 +138,8 @@ static const char *_cudaGetErrorEnum(cufftResult error) {
     case CUFFT_UNALIGNED_DATA:
       return "CUFFT_UNALIGNED_DATA";
 
-    case CUFFT_INCOMPLETE_PARAMETER_LIST:
-      return "CUFFT_INCOMPLETE_PARAMETER_LIST";
-
     case CUFFT_INVALID_DEVICE:
       return "CUFFT_INVALID_DEVICE";
-
-    case CUFFT_PARSE_ERROR:
-      return "CUFFT_PARSE_ERROR";
 
     case CUFFT_NO_WORKSPACE:
       return "CUFFT_NO_WORKSPACE";
@@ -137,11 +147,20 @@ static const char *_cudaGetErrorEnum(cufftResult error) {
     case CUFFT_NOT_IMPLEMENTED:
       return "CUFFT_NOT_IMPLEMENTED";
 
-    case CUFFT_LICENSE_ERROR:
-      return "CUFFT_LICENSE_ERROR";
-
     case CUFFT_NOT_SUPPORTED:
       return "CUFFT_NOT_SUPPORTED";
+
+    case CUFFT_MISSING_DEPENDENCY:
+      return "CUFFT_MISSING_DEPENDENCY";
+
+    case CUFFT_NVRTC_FAILURE:
+      return "CUFFT_NVRTC_FAILURE";
+
+    case CUFFT_NVJITLINK_FAILURE:
+      return "CUFFT_NVJITLINK_FAILURE";
+
+    case CUFFT_NVSHMEM_FAILURE:
+      return "CUFFT_NVSHMEM_FAILURE";
   }
 
   return "<unknown>";
@@ -649,6 +668,15 @@ inline int _ConvertSMVer2Cores(int major, int minor) {
       {0x75,  64},
       {0x80,  64},
       {0x86, 128},
+      {0x87, 128},
+      {0x89, 128},
+      {0x90, 128},
+      {0xa0, 128},
+      {0xa1, 128},
+      {0xa3, 128},
+      {0xb0, 128},
+      {0xc0, 128},
+      {0xc1, 128},
       {-1, -1}};
 
   int index = 0;
@@ -695,6 +723,15 @@ inline const char* _ConvertSMVer2ArchName(int major, int minor) {
       {0x75, "Turing"},
       {0x80, "Ampere"},
       {0x86, "Ampere"},
+      {0x87, "Ampere"},
+      {0x89, "Ada"},
+      {0x90, "Hopper"},
+      {0xa0, "Blackwell"},
+      {0xa1, "Blackwell"},
+      {0xa3, "Blackwell"},
+      {0xb0, "Blackwell"},
+      {0xc0, "Blackwell"},
+      {0xc1, "Blackwell"},
       {-1, "Graphics Device"}};
 
   int index = 0;
@@ -864,7 +901,7 @@ inline int findCudaDevice(int argc, const char **argv) {
     // Otherwise pick the device with highest Gflops/s
     devID = gpuGetMaxGflopsDeviceId();
     checkCudaErrors(cudaSetDevice(devID));
-    int major = 0, minor = 0; 
+    int major = 0, minor = 0;
     checkCudaErrors(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, devID));
     checkCudaErrors(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, devID));
     printf("GPU Device %d: \"%s\" with compute capability %d.%d\n\n",
@@ -897,7 +934,7 @@ inline int findIntegratedGPU() {
     if (integrated && (computeMode != cudaComputeModeProhibited)) {
       checkCudaErrors(cudaSetDevice(current_device));
 
-      int major = 0, minor = 0; 
+      int major = 0, minor = 0;
       checkCudaErrors(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, current_device));
       checkCudaErrors(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, current_device));
       printf("GPU Device %d: \"%s\" with compute capability %d.%d\n\n",

--- a/Velvet/External/cuda/helper_math.h
+++ b/Velvet/External/cuda/helper_math.h
@@ -1,12 +1,28 @@
-/**
- * Copyright 1993-2013 NVIDIA Corporation.  All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
- * Please refer to the NVIDIA end user license agreement (EULA) associated
- * with this source code for terms and conditions that govern your use of
- * this software. Any use, reproduction, disclosure, or distribution of
- * this software and related documentation outside the terms of the EULA
- * is strictly prohibited.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 /*

--- a/Velvet/External/cuda/helper_string.h
+++ b/Velvet/External/cuda/helper_string.h
@@ -1,12 +1,28 @@
-/**
- * Copyright 1993-2013 NVIDIA Corporation.  All rights reserved.
+/* Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
  *
- * Please refer to the NVIDIA end user license agreement (EULA) associated
- * with this source code for terms and conditions that govern your use of
- * this software. Any use, reproduction, disclosure, or distribution of
- * this software and related documentation outside the terms of the EULA
- * is strictly prohibited.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 // These are helper functions for the SDK samples (string parsing, timers, etc)
@@ -233,7 +249,7 @@ inline bool getCmdLineArgumentString(const int argc, const char **argv,
   if (argc >= 1) {
     for (int i = 1; i < argc; i++) {
       int string_start = stringRemoveDelimiter('-', argv[i]);
-      char *string_argv = const_cast<char*>(&argv[i][string_start]);
+      char *string_argv = const_cast<char *>(&argv[i][string_start]);
       int length = static_cast<int>(strlen(string_ref));
 
       if (!STRNCASECMP(string_argv, string_ref, length)) {
@@ -269,348 +285,82 @@ inline char *sdkFindFilePath(const char *filename,
   // the .exe file, a .bat file launching an .exe, a browser .exe launching the
   // .exe or .bat, etc
   const char *searchPath[] = {
-      "./",  // same dir
-      "./<executable_name>_data_files/",
-      "./common/",                      // "/common/" subdir
-      "./common/data/",                 // "/common/data/" subdir
-      "./data/",                        // "/data/" subdir
-      "./src/",                         // "/src/" subdir
-      "./src/<executable_name>/data/",  // "/src/<executable_name>/data/" subdir
-      "./inc/",                         // "/inc/" subdir
-      "./0_Simple/",                    // "/0_Simple/" subdir
-      "./1_Utilities/",                 // "/1_Utilities/" subdir
-      "./2_Graphics/",                  // "/2_Graphics/" subdir
-      "./3_Imaging/",                   // "/3_Imaging/" subdir
-      "./4_Finance/",                   // "/4_Finance/" subdir
-      "./5_Simulations/",               // "/5_Simulations/" subdir
-      "./6_Advanced/",                  // "/6_Advanced/" subdir
-      "./7_CUDALibraries/",             // "/7_CUDALibraries/" subdir
-      "./8_Android/",                   // "/8_Android/" subdir
-      "./samples/",                     // "/samples/" subdir
+      "./",                                           // same dir
+      "./data/",                                      // same dir
 
-      "./0_Simple/<executable_name>/data/",  // "/0_Simple/<executable_name>/data/"
-                                             // subdir
-      "./1_Utilities/<executable_name>/data/",  // "/1_Utilities/<executable_name>/data/"
-                                                // subdir
-      "./2_Graphics/<executable_name>/data/",  // "/2_Graphics/<executable_name>/data/"
-                                               // subdir
-      "./3_Imaging/<executable_name>/data/",  // "/3_Imaging/<executable_name>/data/"
-                                              // subdir
-      "./4_Finance/<executable_name>/data/",  // "/4_Finance/<executable_name>/data/"
-                                              // subdir
-      "./5_Simulations/<executable_name>/data/",  // "/5_Simulations/<executable_name>/data/"
-                                                  // subdir
-      "./6_Advanced/<executable_name>/data/",  // "/6_Advanced/<executable_name>/data/"
-                                               // subdir
-      "./7_CUDALibraries/<executable_name>/",  // "/7_CUDALibraries/<executable_name>/"
-                                               // subdir
-      "./7_CUDALibraries/<executable_name>/data/",  // "/7_CUDALibraries/<executable_name>/data/"
-                                                    // subdir
+      "../../../../cpp/<executable_name>/",       // up 4 in tree
+      "../../../cpp/<executable_name>/",          // up 3 in tree
+      "../../cpp/<executable_name>/",             // up 2 in tree
 
-      "../",              // up 1 in tree
-      "../common/",       // up 1 in tree, "/common/" subdir
-      "../common/data/",  // up 1 in tree, "/common/data/" subdir
-      "../data/",         // up 1 in tree, "/data/" subdir
-      "../src/",          // up 1 in tree, "/src/" subdir
-      "../inc/",          // up 1 in tree, "/inc/" subdir
+      "../../../../cpp/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/<executable_name>/data/",        // up 2 in tree
 
-      "../0_Simple/<executable_name>/data/",  // up 1 in tree,
-                                              // "/0_Simple/<executable_name>/"
-                                              // subdir
-      "../1_Utilities/<executable_name>/data/",  // up 1 in tree,
-                                                 // "/1_Utilities/<executable_name>/"
-                                                 // subdir
-      "../2_Graphics/<executable_name>/data/",  // up 1 in tree,
-                                                // "/2_Graphics/<executable_name>/"
-                                                // subdir
-      "../3_Imaging/<executable_name>/data/",  // up 1 in tree,
-                                               // "/3_Imaging/<executable_name>/"
-                                               // subdir
-      "../4_Finance/<executable_name>/data/",  // up 1 in tree,
-                                               // "/4_Finance/<executable_name>/"
-                                               // subdir
-      "../5_Simulations/<executable_name>/data/",  // up 1 in tree,
-                                                   // "/5_Simulations/<executable_name>/"
-                                                   // subdir
-      "../6_Advanced/<executable_name>/data/",  // up 1 in tree,
-                                                // "/6_Advanced/<executable_name>/"
-                                                // subdir
-      "../7_CUDALibraries/<executable_name>/data/",  // up 1 in tree,
-                                                     // "/7_CUDALibraries/<executable_name>/"
-                                                     // subdir
-      "../8_Android/<executable_name>/data/",  // up 1 in tree,
-                                               // "/8_Android/<executable_name>/"
-                                               // subdir
-      "../samples/<executable_name>/data/",  // up 1 in tree,
-                                             // "/samples/<executable_name>/"
-                                             // subdir
-      "../../",                              // up 2 in tree
-      "../../common/",                       // up 2 in tree, "/common/" subdir
-      "../../common/data/",  // up 2 in tree, "/common/data/" subdir
-      "../../data/",         // up 2 in tree, "/data/" subdir
-      "../../src/",          // up 2 in tree, "/src/" subdir
-      "../../inc/",          // up 2 in tree, "/inc/" subdir
-      "../../sandbox/<executable_name>/data/",  // up 2 in tree,
-                                                // "/sandbox/<executable_name>/"
-                                                // subdir
-      "../../0_Simple/<executable_name>/data/",  // up 2 in tree,
-                                                 // "/0_Simple/<executable_name>/"
-                                                 // subdir
-      "../../1_Utilities/<executable_name>/data/",  // up 2 in tree,
-                                                    // "/1_Utilities/<executable_name>/"
-                                                    // subdir
-      "../../2_Graphics/<executable_name>/data/",  // up 2 in tree,
-                                                   // "/2_Graphics/<executable_name>/"
-                                                   // subdir
-      "../../3_Imaging/<executable_name>/data/",  // up 2 in tree,
-                                                  // "/3_Imaging/<executable_name>/"
-                                                  // subdir
-      "../../4_Finance/<executable_name>/data/",  // up 2 in tree,
-                                                  // "/4_Finance/<executable_name>/"
-                                                  // subdir
-      "../../5_Simulations/<executable_name>/data/",  // up 2 in tree,
-                                                      // "/5_Simulations/<executable_name>/"
-                                                      // subdir
-      "../../6_Advanced/<executable_name>/data/",  // up 2 in tree,
-                                                   // "/6_Advanced/<executable_name>/"
-                                                   // subdir
-      "../../7_CUDALibraries/<executable_name>/data/",  // up 2 in tree,
-                                                        // "/7_CUDALibraries/<executable_name>/"
-                                                        // subdir
-      "../../8_Android/<executable_name>/data/",  // up 2 in tree,
-                                                  // "/8_Android/<executable_name>/"
-                                                  // subdir
-      "../../samples/<executable_name>/data/",  // up 2 in tree,
-                                                // "/samples/<executable_name>/"
-                                                // subdir
-      "../../../",                              // up 3 in tree
-      "../../../src/<executable_name>/",        // up 3 in tree,
-                                          // "/src/<executable_name>/" subdir
-      "../../../src/<executable_name>/data/",  // up 3 in tree,
-                                               // "/src/<executable_name>/data/"
-                                               // subdir
-      "../../../src/<executable_name>/src/",   // up 3 in tree,
-                                               // "/src/<executable_name>/src/"
-                                               // subdir
-      "../../../src/<executable_name>/inc/",   // up 3 in tree,
-                                               // "/src/<executable_name>/inc/"
-                                               // subdir
-      "../../../sandbox/<executable_name>/",   // up 3 in tree,
-                                               // "/sandbox/<executable_name>/"
-                                               // subdir
-      "../../../sandbox/<executable_name>/data/",  // up 3 in tree,
-                                                   // "/sandbox/<executable_name>/data/"
-                                                   // subdir
-      "../../../sandbox/<executable_name>/src/",  // up 3 in tree,
-                                                  // "/sandbox/<executable_name>/src/"
-                                                  // subdir
-      "../../../sandbox/<executable_name>/inc/",  // up 3 in tree,
-                                                  // "/sandbox/<executable_name>/inc/"
-                                                  // subdir
-      "../../../0_Simple/<executable_name>/data/",  // up 3 in tree,
-                                                    // "/0_Simple/<executable_name>/"
-                                                    // subdir
-      "../../../1_Utilities/<executable_name>/data/",  // up 3 in tree,
-                                                       // "/1_Utilities/<executable_name>/"
-                                                       // subdir
-      "../../../2_Graphics/<executable_name>/data/",  // up 3 in tree,
-                                                      // "/2_Graphics/<executable_name>/"
-                                                      // subdir
-      "../../../3_Imaging/<executable_name>/data/",  // up 3 in tree,
-                                                     // "/3_Imaging/<executable_name>/"
-                                                     // subdir
-      "../../../4_Finance/<executable_name>/data/",  // up 3 in tree,
-                                                     // "/4_Finance/<executable_name>/"
-                                                     // subdir
-      "../../../5_Simulations/<executable_name>/data/",  // up 3 in tree,
-                                                         // "/5_Simulations/<executable_name>/"
-                                                         // subdir
-      "../../../6_Advanced/<executable_name>/data/",  // up 3 in tree,
-                                                      // "/6_Advanced/<executable_name>/"
-                                                      // subdir
-      "../../../7_CUDALibraries/<executable_name>/data/",  // up 3 in tree,
-                                                           // "/7_CUDALibraries/<executable_name>/"
-                                                           // subdir
-      "../../../8_Android/<executable_name>/data/",  // up 3 in tree,
-                                                     // "/8_Android/<executable_name>/"
-                                                     // subdir
-      "../../../0_Simple/<executable_name>/",  // up 3 in tree,
-                                               // "/0_Simple/<executable_name>/"
-                                               // subdir
-      "../../../1_Utilities/<executable_name>/",  // up 3 in tree,
-                                                  // "/1_Utilities/<executable_name>/"
-                                                  // subdir
-      "../../../2_Graphics/<executable_name>/",  // up 3 in tree,
-                                                 // "/2_Graphics/<executable_name>/"
-                                                 // subdir
-      "../../../3_Imaging/<executable_name>/",  // up 3 in tree,
-                                                // "/3_Imaging/<executable_name>/"
-                                                // subdir
-      "../../../4_Finance/<executable_name>/",  // up 3 in tree,
-                                                // "/4_Finance/<executable_name>/"
-                                                // subdir
-      "../../../5_Simulations/<executable_name>/",  // up 3 in tree,
-                                                    // "/5_Simulations/<executable_name>/"
-                                                    // subdir
-      "../../../6_Advanced/<executable_name>/",  // up 3 in tree,
-                                                 // "/6_Advanced/<executable_name>/"
-                                                 // subdir
-      "../../../7_CUDALibraries/<executable_name>/",  // up 3 in tree,
-                                                      // "/7_CUDALibraries/<executable_name>/"
-                                                      // subdir
-      "../../../8_Android/<executable_name>/",  // up 3 in tree,
-                                                // "/8_Android/<executable_name>/"
-                                                // subdir
-      "../../../samples/<executable_name>/data/",  // up 3 in tree,
-                                                   // "/samples/<executable_name>/"
-                                                   // subdir
-      "../../../common/",       // up 3 in tree, "../../../common/" subdir
-      "../../../common/data/",  // up 3 in tree, "../../../common/data/" subdir
-      "../../../data/",         // up 3 in tree, "../../../data/" subdir
-      "../../../../",           // up 4 in tree
-      "../../../../src/<executable_name>/",  // up 4 in tree,
-                                             // "/src/<executable_name>/" subdir
-      "../../../../src/<executable_name>/data/",  // up 4 in tree,
-                                                  // "/src/<executable_name>/data/"
-                                                  // subdir
-      "../../../../src/<executable_name>/src/",  // up 4 in tree,
-                                                 // "/src/<executable_name>/src/"
-                                                 // subdir
-      "../../../../src/<executable_name>/inc/",  // up 4 in tree,
-                                                 // "/src/<executable_name>/inc/"
-                                                 // subdir
-      "../../../../sandbox/<executable_name>/",  // up 4 in tree,
-                                                 // "/sandbox/<executable_name>/"
-                                                 // subdir
-      "../../../../sandbox/<executable_name>/data/",  // up 4 in tree,
-                                                      // "/sandbox/<executable_name>/data/"
-                                                      // subdir
-      "../../../../sandbox/<executable_name>/src/",  // up 4 in tree,
-                                                     // "/sandbox/<executable_name>/src/"
-                                                     // subdir
-      "../../../../sandbox/<executable_name>/inc/",  // up 4 in tree,
-                                                     // "/sandbox/<executable_name>/inc/"
-                                                     // subdir
-      "../../../../0_Simple/<executable_name>/data/",  // up 4 in tree,
-                                                       // "/0_Simple/<executable_name>/"
-                                                       // subdir
-      "../../../../1_Utilities/<executable_name>/data/",  // up 4 in tree,
-                                                          // "/1_Utilities/<executable_name>/"
-                                                          // subdir
-      "../../../../2_Graphics/<executable_name>/data/",  // up 4 in tree,
-                                                         // "/2_Graphics/<executable_name>/"
-                                                         // subdir
-      "../../../../3_Imaging/<executable_name>/data/",  // up 4 in tree,
-                                                        // "/3_Imaging/<executable_name>/"
-                                                        // subdir
-      "../../../../4_Finance/<executable_name>/data/",  // up 4 in tree,
-                                                        // "/4_Finance/<executable_name>/"
-                                                        // subdir
-      "../../../../5_Simulations/<executable_name>/data/",  // up 4 in tree,
-                                                            // "/5_Simulations/<executable_name>/"
-                                                            // subdir
-      "../../../../6_Advanced/<executable_name>/data/",  // up 4 in tree,
-                                                         // "/6_Advanced/<executable_name>/"
-                                                         // subdir
-      "../../../../7_CUDALibraries/<executable_name>/data/",  // up 4 in tree,
-                                                              // "/7_CUDALibraries/<executable_name>/"
-                                                              // subdir
-      "../../../../8_Android/<executable_name>/data/",  // up 4 in tree,
-                                                        // "/8_Android/<executable_name>/"
-                                                        // subdir
-      "../../../../0_Simple/<executable_name>/",  // up 4 in tree,
-                                                  // "/0_Simple/<executable_name>/"
-                                                  // subdir
-      "../../../../1_Utilities/<executable_name>/",  // up 4 in tree,
-                                                     // "/1_Utilities/<executable_name>/"
-                                                     // subdir
-      "../../../../2_Graphics/<executable_name>/",  // up 4 in tree,
-                                                    // "/2_Graphics/<executable_name>/"
-                                                    // subdir
-      "../../../../3_Imaging/<executable_name>/",  // up 4 in tree,
-                                                   // "/3_Imaging/<executable_name>/"
-                                                   // subdir
-      "../../../../4_Finance/<executable_name>/",  // up 4 in tree,
-                                                   // "/4_Finance/<executable_name>/"
-                                                   // subdir
-      "../../../../5_Simulations/<executable_name>/",  // up 4 in tree,
-                                                       // "/5_Simulations/<executable_name>/"
-                                                       // subdir
-      "../../../../6_Advanced/<executable_name>/",  // up 4 in tree,
-                                                    // "/6_Advanced/<executable_name>/"
-                                                    // subdir
-      "../../../../7_CUDALibraries/<executable_name>/",  // up 4 in tree,
-                                                         // "/7_CUDALibraries/<executable_name>/"
-                                                         // subdir
-      "../../../../8_Android/<executable_name>/",  // up 4 in tree,
-                                                   // "/8_Android/<executable_name>/"
-                                                   // subdir
-      "../../../../samples/<executable_name>/data/",  // up 4 in tree,
-                                                      // "/samples/<executable_name>/"
-                                                      // subdir
-      "../../../../common/",       // up 4 in tree, "../../../common/" subdir
-      "../../../../common/data/",  // up 4 in tree, "../../../common/data/"
-                                   // subdir
-      "../../../../data/",         // up 4 in tree, "../../../data/" subdir
-      "../../../../../",           // up 5 in tree
-      "../../../../../src/<executable_name>/",  // up 5 in tree,
-                                                // "/src/<executable_name>/"
-                                                // subdir
-      "../../../../../src/<executable_name>/data/",  // up 5 in tree,
-                                                     // "/src/<executable_name>/data/"
-                                                     // subdir
-      "../../../../../src/<executable_name>/src/",  // up 5 in tree,
-                                                    // "/src/<executable_name>/src/"
-                                                    // subdir
-      "../../../../../src/<executable_name>/inc/",  // up 5 in tree,
-                                                    // "/src/<executable_name>/inc/"
-                                                    // subdir
-      "../../../../../sandbox/<executable_name>/",  // up 5 in tree,
-                                                    // "/sandbox/<executable_name>/"
-                                                    // subdir
-      "../../../../../sandbox/<executable_name>/data/",  // up 5 in tree,
-                                                         // "/sandbox/<executable_name>/data/"
-                                                         // subdir
-      "../../../../../sandbox/<executable_name>/src/",  // up 5 in tree,
-                                                        // "/sandbox/<executable_name>/src/"
-                                                        // subdir
-      "../../../../../sandbox/<executable_name>/inc/",  // up 5 in tree,
-                                                        // "/sandbox/<executable_name>/inc/"
-                                                        // subdir
-      "../../../../../0_Simple/<executable_name>/data/",  // up 5 in tree,
-                                                          // "/0_Simple/<executable_name>/"
-                                                          // subdir
-      "../../../../../1_Utilities/<executable_name>/data/",  // up 5 in tree,
-                                                             // "/1_Utilities/<executable_name>/"
-                                                             // subdir
-      "../../../../../2_Graphics/<executable_name>/data/",  // up 5 in tree,
-                                                            // "/2_Graphics/<executable_name>/"
-                                                            // subdir
-      "../../../../../3_Imaging/<executable_name>/data/",  // up 5 in tree,
-                                                           // "/3_Imaging/<executable_name>/"
-                                                           // subdir
-      "../../../../../4_Finance/<executable_name>/data/",  // up 5 in tree,
-                                                           // "/4_Finance/<executable_name>/"
-                                                           // subdir
-      "../../../../../5_Simulations/<executable_name>/data/",  // up 5 in tree,
-                                                               // "/5_Simulations/<executable_name>/"
-                                                               // subdir
-      "../../../../../6_Advanced/<executable_name>/data/",  // up 5 in tree,
-                                                            // "/6_Advanced/<executable_name>/"
-                                                            // subdir
-      "../../../../../7_CUDALibraries/<executable_name>/data/",  // up 5 in
-                                                                 // tree,
-                                                                 // "/7_CUDALibraries/<executable_name>/"
-                                                                 // subdir
-      "../../../../../8_Android/<executable_name>/data/",  // up 5 in tree,
-                                                           // "/8_Android/<executable_name>/"
-                                                           // subdir
-      "../../../../../samples/<executable_name>/data/",  // up 5 in tree,
-                                                         // "/samples/<executable_name>/"
-                                                         // subdir
-      "../../../../../common/",       // up 5 in tree, "../../../common/" subdir
-      "../../../../../common/data/",  // up 5 in tree, "../../../common/data/"
-                                      // subdir
+      "../../../../cpp/0_Introduction/<executable_name>/",  // up 4 in tree
+      "../../../cpp/0_Introduction/<executable_name>/",     // up 3 in tree
+      "../../cpp/0_Introduction/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/1_Utilities/<executable_name>/",  // up 4 in tree
+      "../../../cpp/1_Utilities/<executable_name>/",     // up 3 in tree
+      "../../cpp/1_Utilities/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/2_Concepts_and_Techniques/<executable_name>/",  // up 4 in tree
+      "../../../cpp/2_Concepts_and_Techniques/<executable_name>/",     // up 3 in tree
+      "../../cpp/2_Concepts_and_Techniques/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/3_CUDA_Features/<executable_name>/",  // up 4 in tree
+      "../../../cpp/3_CUDA_Features/<executable_name>/",     // up 3 in tree
+      "../../cpp/3_CUDA_Features/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/4_CUDA_Libraries/<executable_name>/",  // up 4 in tree
+      "../../../cpp/4_CUDA_Libraries/<executable_name>/",     // up 3 in tree
+      "../../cpp/4_CUDA_Libraries/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/5_Domain_Specific/<executable_name>/",  // up 4 in tree
+      "../../../cpp/5_Domain_Specific/<executable_name>/",     // up 3 in tree
+      "../../cpp/5_Domain_Specific/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/6_Performance/<executable_name>/",  // up 4 in tree
+      "../../../cpp/6_Performance/<executable_name>/",     // up 3 in tree
+      "../../cpp/6_Performance/<executable_name>/",        // up 2 in tree
+
+      "../../../../cpp/0_Introduction/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/0_Introduction/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/0_Introduction/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/1_Utilities/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/1_Utilities/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/1_Utilities/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/2_Concepts_and_Techniques/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/2_Concepts_and_Techniques/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/2_Concepts_and_Techniques/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/3_CUDA_Features/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/3_CUDA_Features/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/3_CUDA_Features/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/4_CUDA_Libraries/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/4_CUDA_Libraries/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/4_CUDA_Libraries/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/5_Domain_Specific/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/5_Domain_Specific/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/5_Domain_Specific/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../cpp/6_Performance/<executable_name>/data/",  // up 4 in tree
+      "../../../cpp/6_Performance/<executable_name>/data/",     // up 3 in tree
+      "../../cpp/6_Performance/<executable_name>/data/",        // up 2 in tree
+
+      "../../../../Common/data/",                     // up 4 in tree
+      "../../../Common/data/",                        // up 3 in tree
+      "../../Common/data/",                           // up 2 in tree
+
+      "../../../../cpp/9_CUDA_Tile/<executable_name>/",        // up 4 in tree
+      "../../../cpp/9_CUDA_Tile/<executable_name>/",           // up 3 in tree
+      "../../cpp/9_CUDA_Tile/<executable_name>/",              // up 2 in tree
+      "../cpp/9_CUDA_Tile/<executable_name>/",                 // up 1 in tree
+      "./cpp/9_CUDA_Tile/<executable_name>/"                   // up 0 in tree
   };
 
   // Extract the executable name
@@ -677,6 +427,7 @@ inline char *sdkFindFilePath(const char *filename,
   }
 
   // File not found
+  printf("\nerror: sdkFindFilePath: file <%s> not found!\n", filename);
   return 0;
 }
 

--- a/Velvet/GameInstance.hpp
+++ b/Velvet/GameInstance.hpp
@@ -11,6 +11,7 @@
 
 #include "Component.hpp"
 #include "Common.hpp"
+#include "Actor.hpp"
 
 namespace Velvet
 {
@@ -19,7 +20,6 @@ namespace Velvet
 	class Light;
 	class RenderPipeline;
 	class GUI;
-	class Actor;
 	class Timer;
 
 	class GameInstance

--- a/Velvet/Helper.cpp
+++ b/Velvet/Helper.cpp
@@ -1,5 +1,5 @@
 #include "Helper.hpp"
-#include <glm\ext\matrix_transform.hpp>
+#include <glm/ext/matrix_transform.hpp>
 
 namespace Velvet
 {

--- a/Velvet/Helper.hpp
+++ b/Velvet/Helper.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <algorithm>
 #include <fmt/format.h>
-//#include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
 
 template <>
 struct fmt::formatter<glm::vec3> : fmt::formatter<std::string> {
-	auto format(glm::vec3 p, format_context& ctx) {
+	auto format(glm::vec3 p, format_context& ctx) const {
 		return formatter<std::string>::format(
 			fmt::format("[{:.2f}, {:.2f}, {:.2f}]", p.x, p.y, p.z), ctx);
 	}
@@ -14,7 +14,7 @@ struct fmt::formatter<glm::vec3> : fmt::formatter<std::string> {
 
 template <>
 struct fmt::formatter<glm::vec2> : fmt::formatter<std::string> {
-	auto format(glm::vec2 p, format_context& ctx) {
+	auto format(glm::vec2 p, format_context& ctx) const {
 		return formatter<std::string>::format(
 			fmt::format("[{:.2f}, {:.2f}]", p.x, p.y), ctx);
 	}
@@ -35,7 +35,7 @@ namespace Velvet
 		template <class T>
 		T Lerp(T value1, T value2, float a)
 		{
-			a = min(max(a, 0.0f), 1.0f);
+			a = std::min(std::max(a, 0.0f), 1.0f);
 			return a * value2 + (1 - a) * value1;
 		}
 	}

--- a/Velvet/SpatialHashGPU.cu
+++ b/Velvet/SpatialHashGPU.cu
@@ -1,6 +1,11 @@
 #include "SpatialHashGPU.cuh"
 
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
 #include <cub/device/device_radix_sort.cuh>
+#endif
 
 #include "Timer.hpp"
 #include "VtBuffer.hpp"

--- a/Velvet/SpatialHashGPU.hpp
+++ b/Velvet/SpatialHashGPU.hpp
@@ -3,10 +3,12 @@
 #include <unordered_set>
 
 #include <glm/glm.hpp>
+#include <fmt/ranges.h>
 
+#include "cuda_to_hip.h"
 #include "VtBuffer.hpp"
 #include "Global.hpp"
-#include "SpatialhashGPU.cuh"
+#include "SpatialHashGPU.cuh"
 
 using namespace std;
 

--- a/Velvet/Timer.hpp
+++ b/Velvet/Timer.hpp
@@ -7,7 +7,12 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <fmt/printf.h>
+
+#include "cuda_to_hip.h"
+
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
 #include <cuda_runtime.h>
+#endif
 
 //#include "Global.hpp"
 

--- a/Velvet/VtBuffer.hpp
+++ b/Velvet/VtBuffer.hpp
@@ -182,7 +182,11 @@ namespace Velvet
 		size_t m_numBytes = 0;
 		T* m_buffer = nullptr;
 		T* m_bufferCPU = nullptr;
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+		hipGraphicsResource* m_cudaVboResource = nullptr;
+#else
 		struct cudaGraphicsResource* m_cudaVboResource = nullptr;
+#endif
 	};
 
 	template <class T>

--- a/Velvet/VtBuffer.hpp
+++ b/Velvet/VtBuffer.hpp
@@ -167,15 +167,24 @@ namespace Velvet
 		void registerBuffer(GLuint vbo)
 		{
 			checkCudaErrors(cudaGraphicsGLRegisterBuffer(&m_cudaVboResource, vbo, cudaGraphicsRegisterFlagsNone));
+		}
 
-			// map (example 'gl_cuda_interop_pingpong_st' says map and unmap only needs to be done once)
+		// The mapped device pointer is only valid between map() and unmap(). Holding on to it
+		// after the unmap is undefined, so every access has to happen inside that scope.
+		void map()
+		{
 			checkCudaErrors(cudaGraphicsMapResources(1, &m_cudaVboResource, 0));
 			checkCudaErrors(cudaGraphicsResourceGetMappedPointer((void**)&m_buffer, &m_numBytes,
 				m_cudaVboResource));
 			m_count = m_numBytes / sizeof(T);
+		}
 
-			// unmap
+		// m_count and m_numBytes describe the buffer rather than the mapping, and callers read
+		// them while it is unmapped, so only the pointer is invalidated here.
+		void unmap()
+		{
 			checkCudaErrors(cudaGraphicsUnmapResources(1, &m_cudaVboResource, 0));
+			m_buffer = nullptr;
 		}
 
 		size_t m_count = 0;
@@ -207,6 +216,7 @@ namespace Velvet
 		{
 			auto rbuf = make_shared<VtRegisteredBuffer<T>>();
 			rbuf->registerBuffer(vbo);
+			rbuf->map();
 			m_rbuffers.push_back(rbuf);
 
 			size_t last = m_offsets.size() - 1;
@@ -215,7 +225,8 @@ namespace Velvet
 
 			// copy from rbuffers to vbuffer
 			m_vbuffer.resize(m_vbuffer.size() + rbuf->size());
-			cudaMemcpy(m_vbuffer.data() + offset, rbuf->data(), rbuf->size() * sizeof(T), cudaMemcpyDefault);
+			checkCudaErrors(cudaMemcpy(m_vbuffer.data() + offset, rbuf->data(), rbuf->size() * sizeof(T), cudaMemcpyDefault));
+			rbuf->unmap();
 		}
 
 		size_t size() const
@@ -228,7 +239,9 @@ namespace Velvet
 			// copy from vbuffer to rbuffers
 			for (int i = 0; i < m_rbuffers.size(); i++)
 			{
-				cudaMemcpy(m_rbuffers[i]->data(), m_vbuffer.data() + m_offsets[i], m_rbuffers[i]->size() * sizeof(T), cudaMemcpyDefault);
+				m_rbuffers[i]->map();
+				checkCudaErrors(cudaMemcpy(m_rbuffers[i]->data(), m_vbuffer.data() + m_offsets[i], m_rbuffers[i]->size() * sizeof(T), cudaMemcpyDefault));
+				m_rbuffers[i]->unmap();
 			}
 		}
 

--- a/Velvet/VtClothSolverGPU.hpp
+++ b/Velvet/VtClothSolverGPU.hpp
@@ -4,12 +4,18 @@
 
 #include <glad/glad.h>
 #include <glm/glm.hpp>
+
+#include "cuda_to_hip.h"
+
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
 #include <cuda_runtime.h>
 #include <cuda_gl_interop.h>
+#include "helper_cuda.h"
+#endif
+
 #include <thrust/device_ptr.h>
 #include <thrust/transform.h>
 
-#include "helper_cuda.h"
 #include "Mesh.hpp"
 #include "VtClothSolverGPU.cuh"
 #include "VtBuffer.hpp"

--- a/Velvet/VtEngine.cpp
+++ b/Velvet/VtEngine.cpp
@@ -89,9 +89,9 @@ int VtEngine::Run()
 #pragma warning( push )
 #pragma warning( disable : 4129)
 		fmt::print(
-			"©°{0:\-^{2}}©´\n"
-			"©¦{1: ^{2}}©¦\n"
-			"©¸{0:\-^{2}}©¼\n", "", "Hello, Velvet!", 30);
+			"ï¿½ï¿½{0:\-^{2}}ï¿½ï¿½\n"
+			"ï¿½ï¿½{1: ^{2}}ï¿½ï¿½\n"
+			"ï¿½ï¿½{0:\-^{2}}ï¿½ï¿½\n", "", "Hello, Velvet!", 30);
 #pragma warning( pop ) 
 
 		m_game = make_shared<GameInstance>(m_window, m_gui);

--- a/Velvet/VtEngine.hpp
+++ b/Velvet/VtEngine.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/Velvet/cuda_to_hip.h
+++ b/Velvet/cuda_to_hip.h
@@ -1,0 +1,71 @@
+#pragma once
+
+// CUDA-to-HIP compatibility header for Velvet.
+// Provides CUDA API mappings when building with HIP for AMD GPUs.
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// Author: Jeff Daily <jeff.daily@amd.com>
+
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_gl_interop.h>
+
+// Runtime API - memory
+#define cudaMallocManaged          hipMallocManaged
+#define cudaFree                   hipFree
+#define cudaMemcpy                 hipMemcpy
+#define cudaMemcpyDefault          hipMemcpyDefault
+#define cudaMemsetAsync            hipMemsetAsync
+#define cudaDeviceSynchronize      hipDeviceSynchronize
+#define cudaMemcpyHostToDevice     hipMemcpyHostToDevice
+
+// hipMemcpyToSymbolAsync requires offset and kind args; CUDA has defaults
+#define cudaMemcpyToSymbolAsync(symbol, src, size) \
+    hipMemcpyToSymbolAsync(symbol, src, size, 0, hipMemcpyHostToDevice, 0)
+
+// Events
+#define cudaEvent_t                hipEvent_t
+#define cudaEventCreate            hipEventCreate
+#define cudaEventRecord            hipEventRecord
+#define cudaEventSynchronize       hipEventSynchronize
+#define cudaEventElapsedTime       hipEventElapsedTime
+#define cudaEventDestroy           hipEventDestroy
+
+// Error handling
+#define cudaError_t                hipError_t
+#define cudaSuccess                hipSuccess
+#define cudaGetErrorName           hipGetErrorName
+#define cudaGetLastError           hipGetLastError
+
+// OpenGL interop
+#define cudaGraphicsResource       hipGraphicsResource
+#define cudaGraphicsGLRegisterBuffer       hipGraphicsGLRegisterBuffer
+#define cudaGraphicsMapResources           hipGraphicsMapResources
+#define cudaGraphicsResourceGetMappedPointer hipGraphicsResourceGetMappedPointer
+#define cudaGraphicsUnmapResources         hipGraphicsUnmapResources
+#define cudaGraphicsUnregisterResource     hipGraphicsUnregisterResource
+#define cudaGraphicsRegisterFlagsNone      hipGraphicsRegisterFlagsNone
+
+// checkCudaErrors macro for HIP
+#ifndef checkCudaErrors
+#define checkCudaErrors(val) __checkCudaErrors((val), #val, __FILE__, __LINE__)
+
+template <typename T>
+void __checkCudaErrors(T result, const char *const func, const char *const file,
+                       int const line) {
+  if (result != hipSuccess) {
+    fprintf(stderr, "HIP error at %s:%d code=%d(%s) \"%s\" \n", file, line,
+            static_cast<unsigned int>(result), hipGetErrorName(result), func);
+    exit(EXIT_FAILURE);
+  }
+}
+#endif
+
+#else  // CUDA path
+
+#include <cuda_runtime.h>
+#include <cuda_gl_interop.h>
+#include <helper_cuda.h>
+
+#endif

--- a/Velvet/cuda_to_hip.h
+++ b/Velvet/cuda_to_hip.h
@@ -8,6 +8,9 @@
 
 #if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
 
+#include <cstdio>
+#include <cstdlib>
+
 #include <hip/hip_runtime.h>
 #include <hip/hip_gl_interop.h>
 
@@ -47,25 +50,33 @@
 #define cudaGraphicsUnregisterResource     hipGraphicsUnregisterResource
 #define cudaGraphicsRegisterFlagsNone      hipGraphicsRegisterFlagsNone
 
-// checkCudaErrors macro for HIP
-#ifndef checkCudaErrors
-#define checkCudaErrors(val) __checkCudaErrors((val), #val, __FILE__, __LINE__)
-
-template <typename T>
-void __checkCudaErrors(T result, const char *const func, const char *const file,
-                       int const line) {
-  if (result != hipSuccess) {
-    fprintf(stderr, "HIP error at %s:%d code=%d(%s) \"%s\" \n", file, line,
-            static_cast<unsigned int>(result), hipGetErrorName(result), func);
-    exit(EXIT_FAILURE);
-  }
+// Status check for the call sites that spell it checkCudaErrors(). The CUDA
+// build gets that macro from the CUDA samples helper header; the HIP build
+// uses this instead, so no CUDA samples header is on the AMD include path.
+namespace Velvet
+{
+	inline void AbortOnHipError(hipError_t status, const char* expr,
+		const char* file, int line)
+	{
+		if (status == hipSuccess)
+		{
+			return;
+		}
+		std::fprintf(stderr, "%s:%d: %s -> %s (%d)\n", file, line, expr,
+			hipGetErrorString(status), static_cast<int>(status));
+		std::exit(EXIT_FAILURE);
+	}
 }
+
+#ifndef checkCudaErrors
+#define checkCudaErrors(expr) \
+	::Velvet::AbortOnHipError((expr), #expr, __FILE__, __LINE__)
 #endif
 
 #else  // CUDA path
 
 #include <cuda_runtime.h>
 #include <cuda_gl_interop.h>
-#include <helper_cuda.h>
+#include <helper_cuda.h>  // checkCudaErrors, from Velvet/External/cuda
 
 #endif


### PR DESCRIPTION
This adds a HIP/ROCm build of Velvet so the cloth simulator runs on AMD GPUs, alongside the existing CUDA build. The AMD support arrives through a new CMake build with a `USE_HIP` option; the upstream Visual Studio / CUDA project is left intact. No source files are renamed, and the AMD-specific code is guarded by `USE_HIP` except where noted below, so the CUDA build is preserved.

How to review: `CMakeLists.txt` first (the build wiring), then `Velvet/cuda_to_hip.h` (the CUDA to HIP symbol mapping), then `Velvet/VtBuffer.hpp` (the one change that is not AMD-specific), then the small per-source changes, then the README build section.

## The build

`CMakeLists.txt` is new; the project shipped only a Visual Studio solution. It builds with CUDA by default and with HIP when `-DUSE_HIP=ON`.

Only the two `.cu` files are compiled as HIP. The `.cpp` files stay plain C++, which matters: `HOST_INIT(val)` in `Velvet/Common.hpp` expands to nothing under `__CUDACC__` or `__HIPCC__`, so compiling host sources as HIP silently drops every default member initializer in `VtSimParams`, including the global the solve loop reads.

Keeping the split needs one more thing. `hip::hipcub` and `roc::rocthrust` pull in `roc::rocprim_hip` and therefore `hip::device`, whose compile options are attached with a `$<$<COMPILE_LANGUAGE:CXX>:...>` generator expression and so land on exactly the plain C++ sources. The build takes those packages' include directories instead and links `hip::host`. All three are header-only here, so nothing is lost.

Because the host sources now reach hipCUB, rocThrust and the HIP headers through `Common.cuh`, the ROCm build needs the ROCm clang for `CXX` as well as for `HIP`. The README says so and gives the invocation.

Dependencies come from vcpkg, matching the upstream build instructions (glfw3, glad, fmt, glm, assimp, imgui). GLM is taken from vcpkg because its 1.0.x release adds the HIP compiler detection the bundled copy lacks.

## The compatibility shim

`Velvet/cuda_to_hip.h` is active only under `USE_HIP`. It maps the CUDA runtime and OpenGL-interop symbols the project uses onto their `hip*` equivalents, and defines `THRUST_DEVICE_SYSTEM` as HIP before Thrust is included, because rocThrust checks `__CUDACC__` before `__HIP__` and would otherwise select the CUDA backend. On NVIDIA the header is an empty passthrough.

## Two changes outside the build system

`Velvet/Common.cuh`: the `CUDA_CALL` macros were gated on `__CUDACC__` only, which hipcc does not define, so on HIP they expanded to empty and every kernel launch silently did nothing. They are now also enabled under `__HIPCC__`.

`Velvet/VtBuffer.hpp` is **not** AMD-specific and changes the CUDA path too. `VtRegisteredBuffer::registerBuffer()` mapped the OpenGL buffer, took the device pointer, unmapped, and kept using that pointer afterwards. The runtime documents the pointer as valid only while mapped, and on HIP it is invalidated at the unmap: `hipMemcpy` against it returns `hipErrorInvalidValue` and copies nothing. Both uses were unchecked, so the failure was silent, particle positions were never seeded, and the simulation produced NaN within a few frames.

`registerBuffer()` now only registers; explicit `map()` and `unmap()` bracket each device copy, and both copies are checked. `unmap()` clears the pointer but keeps the element counts, because `registerNewBuffer()` computes the next offset from the previous, already-unmapped buffer's `size()`. This is deliberately not guarded by `USE_HIP`: it removes the same undefined behaviour on CUDA, and restores the OpenGL synchronisation that the map/unmap pair provides, which the old code had no equivalent of.

One template parameter pack (`VtCallback::Invoke` in `Common.hpp`) is renamed so it stops shadowing the enclosing class's pack, which nvcc and gcc reject. The `.gitignore` gains the CMake `build/` directory.

## The bundled CUDA sample headers

The three headers under `Velvet/External/cuda` came from a 2013-2017 CUDA samples drop and carried the NVIDIA EULA notice ("Please refer to the NVIDIA end user license agreement (EULA) associated with this source code"). NVIDIA has since republished the same files under BSD 3-Clause, so all three are replaced verbatim with `Common/helper_cuda.h`, `Common/helper_string.h` and `Common/helper_math.h` from NVIDIA/cuda-samples at commit `b7c5481c556c3fe98db060207ecaa41a4b9a9abc`.

This is a licence change to bundled third-party code, which is why it is called out rather than folded into the build commit: the replacements carry "Copyright (c) 2022, NVIDIA CORPORATION" with the BSD 3-Clause redistribution terms in place of the EULA reference. Nothing was deleted and no notice was stripped.

The new files are supersets of the old ones for everything Velvet uses. `checkCudaErrors` is the only name the sources take from them and is defined the same way; `helper_math.h` and `helper_string.h` are included but otherwise unused. The AMD build reads none of the three. The change accounts for most of the line count in this pull request, and none of it is logic.

## Hardware scope

Velvet renders with OpenGL and shares vertex buffers with the GPU through graphics interop, so it needs an AMD GPU with a graphics pipeline. RDNA parts work. Compute-only datacenter parts (CDNA, the Instinct MI series) cannot create the required OpenGL context and so cannot run it at all, which also means the port cannot be exercised there even for the compute paths, since the device buffers are the graphics buffers.

## Test Plan

Build the dependencies once with vcpkg, then configure with HIP and run the simulator:

```
vcpkg install glfw3 glad fmt glm assimp "imgui[core,opengl3-binding,glfw-binding]"
cmake -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx1151 \
      -DCMAKE_C_COMPILER=<rocm>/bin/amdclang -DCMAKE_CXX_COMPILER=<rocm>/bin/amdclang++ \
      -DCMAKE_HIP_COMPILER=<rocm>/bin/amdclang++ \
      -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
cmake --build build -j
./build/bin/Velvet
```

Validated by running the simulator itself on a Radeon 8060S (gfx1151, RDNA3.5) under Windows. Over 600 physics frames the cloth holds its full 2.0 by 2.0 extent, sags from y=1.5 to 0.775 with the attached corners staying at 1.5, and the textured mesh renders with lighting and shadow. The NaN count is zero throughout, both interop copies return success, and the mean stretch residual settles at 0.0097 against a 0.05 rest length. The Self Collision and High Resolution scenes were exercised as well.

The gfx1100 and gfx1201 builds were previously checked for compilation and for HIP kernel execution, not by running the application; those results are superseded by the run above and are not offered as evidence that the simulation is correct.

The CUDA sources were compile-checked with nvcc, but the CUDA build was not linked or run, as no NVIDIA GPU was available.

This work was authored with the assistance of Claude, an AI assistant by Anthropic.
